### PR TITLE
Don't change timeout on pause/unpause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ The rules for this file:
     * YYYY-MM-DD date format (following ISO 8601)
   * accompany each entry with github issue/PR number (Issue #xyz)
 -->
+## [v0.2.3] - 2025-11-08
+### Authors
+@ljwoods2
+
+### Changed
+
+### Added
+
+### Fixed
+* Removed timeout changes during pause/resume for IMDv2 and IMv3
+  (Issue #96, PR #118)
+
+### Deprecated
+<!-- Soon-to-be removed features -->
+
+### Removed
+<!-- Removed features -->
+
 
 ## [v0.2.2] - 2025-07-20
 ### Authors

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -591,7 +591,6 @@ class IMDProducerV2(BaseIMDProducer):
             raise RuntimeError("IMDProducer: Unexpected packet type or length")
 
     def _pause(self):
-        self._conn.settimeout(0)
         logger.debug(
             "IMDProducer: Pausing simulation because buffer is almost full"
         )
@@ -607,7 +606,6 @@ class IMDProducerV2(BaseIMDProducer):
         # from the socket
 
     def _unpause(self):
-        self._conn.settimeout(self._timeout)
         logger.debug("IMDProducer: Unpausing simulation, buffer has space")
         unpause = create_header_bytes(IMDHeaderType.IMD_PAUSE, 0)
         try:
@@ -658,7 +656,6 @@ class IMDProducerV3(BaseIMDProducer):
             self._forces = bytearray(xvf_bytes)
 
     def _pause(self):
-        self._conn.settimeout(0)
         logger.debug(
             "IMDProducer: Pausing simulation because buffer is almost full"
         )
@@ -674,7 +671,6 @@ class IMDProducerV3(BaseIMDProducer):
         # from the socket
 
     def _unpause(self):
-        self._conn.settimeout(self._timeout)
         logger.debug("IMDProducer: Unpausing simulation, buffer has space")
         unpause = create_header_bytes(IMDHeaderType.IMD_RESUME, 0)
         try:


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #96 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Don't change timeout when pausing/unpausing

Bug was occurring because of the following rare event:

- Client pauses simulation, sets timeout to 0 to make socket reads blocking
- Simulation writes an IMDFrame to its socket write buffer, and only i.e. the time packet is delivered "immediately"
- Simulation (correctly) stops sending new frames, but current frame is still in transit
- Client attempts to read an entire frame from the socket, finding only a time packet instead (since the rest is still in-transit)
- Since socket read is currently blocking, client fails out erroneously

This was based on the erroneous assumption that only full frames would be in memory when the simulation was paused, however, this is not true; packets could still be in transit which the simulation engine called `write()` on before the pause was acknowledged. 
 

Thanks to @amruthesht for figuring this out


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
