### PR TITLE
remove anaconda defaults channel from CI

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash -l {0} 
+    shell: bash -el {0} 
 
 jobs:
   environment-config:
@@ -73,12 +73,14 @@ jobs:
         architecture: ${{ env.ARCHITECTURE }}
 
         channels: conda-forge
+        conda-remove-defaults: true
 
         activate-environment: imdclient-test
         auto-update-conda: true
         auto-activate-base: false
         show-channel-urls: true
         miniconda-version: latest
+        conda-solver: libmamba
 
     - name: Install imdclient
       run: |
@@ -153,13 +155,15 @@ jobs:
           architecture: x64
 
           channels: conda-forge
-
+          conda-remove-defaults: true
+        
           activate-environment: imdclient-test
           auto-update-conda: true
           auto-activate-base: false
           show-channel-urls: true
           miniconda-version: latest
-
+          conda-solver: libmamba
+        
       - name: Install package
         run: |
           python --version


### PR DESCRIPTION
Fixes #135

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - remove *defaults* channel
 - explicitly select libmamba solver
 - set default shell to `bash -el {0}` (based on setup-miniconda docs)


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
