### PR TITLE
IMDv2 generic support implementation with tests

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,6 @@ import sys
 sys.path.insert(0, os.path.abspath("../.."))
 import imdclient  # noqa
 
-
 # -- Project information -----------------------------------------------------
 
 project = "IMDClient"

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -598,7 +598,9 @@ class IMDProducerV2(BaseIMDProducer):
                 ).reshape((self._n_atoms, 3)),
             )
         else:
-            raise RuntimeError("IMDProducer: Unexpected packet type")
+            raise RuntimeError(
+                f"IMDProducer: Unexpected packet type {header.type.name}"
+            )
 
     def _pause(self):
         logger.debug(

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -59,6 +59,11 @@ class IMDClient:
         If True, the client will attempt to change the simulation engine's waiting behavior to
         non-blocking after the client disconnects. If False, the client will attempt to change it
         to blocking. If None, the client will not attempt to change the simulation engine's behavior.
+    transmission_rate : int, optional [``None``]
+        IMD transmission rate to be set after client send go signal. 
+        This parameter is only set to the server when using IMDv2. Default behavior is to not set the transmission rate. 
+        This parameter is useful when running GROMACS with IMDv2, where transmission rate can only be set via the client. 
+        IMDv2 implementations in LAMMPS and NAMD support setting the transmission rate via relevant input file parameters.
     **kwargs : dict (optional)
         Additional keyword arguments to pass to the :class:`BaseIMDProducer` and :class:`IMDFrameBuffer`
     """
@@ -303,13 +308,16 @@ class IMDClient:
         return sinfo
 
     def _trate(self, rate):
+        """
+        Send a trate packet to the server to set transmission rate.
+        """
         trate = create_header_bytes(IMDHeaderType.IMD_TRATE, rate)
         self._conn.sendall(trate)
         logger.debug("IMDClient: Sent transmission rate %s", rate)
 
     def _go(self):
         """
-        Send a go packet to the client to start the simulation
+        Send a go packet to the server to start the simulation
         and begin receiving data.
         """
         go = create_header_bytes(IMDHeaderType.IMD_GO, 0)

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -275,13 +275,13 @@ class IMDClient:
             sinfo = IMDSessionInfo(
                 version=ver,
                 endianness=end,
-                wrapped_coords=False,
                 time=False,
                 energies=True,
                 box=False,
                 positions=True,
                 velocities=False,
                 forces=False,
+                wrapped_coords=False,
             )
 
         elif ver == 3:

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -560,12 +560,13 @@ class IMDProducerV2(BaseIMDProducer):
             self._prev_energies = self._imdf.energies
 
             leading_energies += 1
-            if leading_energies == 2:
-                logger.warning(
-                    "IMDProducer: Received multiple leading IMDv2 energy packets before coordinates, energy values may be out of sync with coordinates"
-                )
 
             header = self._get_header()
+
+        if (leading_energies == 0 or leading_energies > 1):
+            logger.warning(
+                f"IMDProducer: Received {leading_energies} leading IMDv2 energy packets before coordinates, energy values may be out of sync with coordinates"
+            )
 
         if (
             header.type == IMDHeaderType.IMD_FCOORDS

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -548,9 +548,10 @@ class IMDProducerV2(BaseIMDProducer):
         # Even if they are sent, energies might not be sent every frame
         # cache the last energies received
 
-        # Either receive energies + positions or just positions
+        # Consume any leading energy packets first, then handle positions.
         header = self._get_header()
-        if header.type == IMDHeaderType.IMD_ENERGIES and header.length == 1:
+        leading_energies = 0
+        while header.type == IMDHeaderType.IMD_ENERGIES and header.length == 1:
             self._imdsinfo.energies = True
             self._read(self._energies)
             self._imdf.energies.update(
@@ -558,17 +559,15 @@ class IMDProducerV2(BaseIMDProducer):
             )
             self._prev_energies = self._imdf.energies
 
-            self._expect_header(
-                IMDHeaderType.IMD_FCOORDS, expected_value=self._n_atoms
-            )
-            self._read(self._positions)
-            np.copyto(
-                self._imdf.positions,
-                np.frombuffer(
-                    self._positions, dtype=f"{self._imdsinfo.endianness}f"
-                ).reshape((self._n_atoms, 3)),
-            )
-        elif (
+            leading_energies += 1
+            if leading_energies == 2:
+                logger.warning(
+                    "IMDProducer: Received multiple leading IMDv2 energy packets before coordinates, energy values may be out of sync with coordinates"
+                )
+
+            header = self._get_header()
+
+        if (
             header.type == IMDHeaderType.IMD_FCOORDS
             and header.length == self._n_atoms
         ):

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -71,6 +71,7 @@ class IMDClient:
         socket_bufsize=None,
         multithreaded=True,
         continue_after_disconnect=None,
+        transmission_rate=None,
         **kwargs,
     ):
         self._stopped = False
@@ -111,6 +112,9 @@ class IMDClient:
             )
 
         self._go()
+
+        if transmission_rate is not None and self._imdsinfo.version == 2:
+            self._trate(transmission_rate)
 
         if self._multithreaded:
             # Disconnect MUST occur. This covers typical cases (Python, IPython interpreter)
@@ -297,6 +301,11 @@ class IMDClient:
             logger.debug(f"IMDClient: Received IMDv3 session info: {sinfo}")
 
         return sinfo
+
+    def _trate(self, rate):
+        trate = create_header_bytes(IMDHeaderType.IMD_TRATE, rate)
+        self._conn.sendall(trate)
+        logger.debug("IMDClient: Sent transmission rate %s", rate)
 
     def _go(self):
         """
@@ -563,7 +572,7 @@ class IMDProducerV2(BaseIMDProducer):
 
             header = self._get_header()
 
-        if (leading_energies == 0 or leading_energies > 1):
+        if leading_energies == 0 or leading_energies > 1:
             logger.warning(
                 f"IMDProducer: Received {leading_energies} leading IMDv2 energy packets before coordinates, energy values may be out of sync with coordinates"
             )

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -577,10 +577,13 @@ class IMDProducerV2(BaseIMDProducer):
                 f"IMDProducer: Received {leading_energies} leading IMDv2 energy packets before coordinates, energy values may be out of sync with coordinates"
             )
 
-        if (
-            header.type == IMDHeaderType.IMD_FCOORDS
-            and header.length == self._n_atoms
-        ):
+        if header.type == IMDHeaderType.IMD_FCOORDS:
+            # check if the number of atoms is correct
+            if header.length != self._n_atoms:
+                raise RuntimeError(
+                    f"IMDProducer: Expected n_atoms value {self._n_atoms}, got {header.length}. "
+                    + "Ensure you are using the correct topology file."
+                )
             # If we received positions but no energies
             # use the last energies received
             if self._prev_energies is not None:
@@ -595,7 +598,7 @@ class IMDProducerV2(BaseIMDProducer):
                 ).reshape((self._n_atoms, 3)),
             )
         else:
-            raise RuntimeError("IMDProducer: Unexpected packet type or length")
+            raise RuntimeError("IMDProducer: Unexpected packet type")
 
     def _pause(self):
         logger.debug(

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -82,7 +82,7 @@ class IMDClient:
         every integrator time step and may impact performance substantially.
 
     .. versionadded:: 0.3.0
-    
+
         Added ``transmission_rate`` parameter to set the IMDv2 transmission
         rate from the client (via an ``IMD_TRATE`` packet) after the go packet
         is sent.
@@ -155,8 +155,15 @@ class IMDClient:
 
         self._go()
 
-        if transmission_rate is not None and self._imdsinfo.version == 2:
-            self._trate(transmission_rate)
+        if transmission_rate is not None:
+            if self._imdsinfo.version == 2:
+                self._trate(transmission_rate)
+            elif self._imdsinfo.version == 3:
+                logger.warning(
+                    "IMDClient: transmission_rate=%s was provided but is ignored for "
+                    "IMDv3 and not automatically sent/set on the server.",
+                    transmission_rate,
+                )
 
         if self._multithreaded:
             # Disconnect MUST occur. This covers typical cases (Python, IPython interpreter)

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -61,12 +61,31 @@ class IMDClient:
         to blocking. If None, the client will not attempt to change the simulation engine's behavior.
         Only supported for IMDv3; must be ``None`` for IMDv2 connections.
     transmission_rate : int, optional [``None``]
-        IMD transmission rate to be set after client send go signal. 
-        This parameter is only set to the server when using IMDv2. Default behavior is to not set the transmission rate. 
-        This parameter is useful when running GROMACS with IMDv2, where transmission rate can only be set via the client. 
-        IMDv2 implementations in LAMMPS and NAMD support setting the transmission rate via relevant input file parameters.
+        IMD :ref:`transmission rate <transmission-rate>` to send after the go
+        packet (for IMDv2 only). The transmission rate is the number of
+        integration steps between each IMD frame; see :doc:`protocol_v3` for
+        more details.
+
+        If ``None``, no ``IMD_TRATE`` packet is sent. IMDv2 in LAMMPS and NAMD
+        allow setting the rate in the simulation input file instead.
+        GROMACS IMDv2 ignores ``IMD-nst`` in the ``*.mdp`` file; the engine
+        starts with a default rate of 1 until the client sends ``IMD_TRATE``.
+
+        .. versionadded:: 0.3.0
     **kwargs : dict (optional)
         Additional keyword arguments to pass to the :class:`BaseIMDProducer` and :class:`IMDFrameBuffer`
+
+    .. warning::
+
+        When using GROMACS with IMDv2, users should set `transmission_rate` explicitly.
+        Otherwise the GROMACS default of 1 will be chosen. This default setting will send
+        every integrator time step and may impact performance substantially.
+
+    .. versionadded:: 0.3.0
+    
+        Added ``transmission_rate`` parameter to set the IMDv2 transmission
+        rate from the client (via an ``IMD_TRATE`` packet) after the go packet
+        is sent.
     """
 
     def __init__(
@@ -342,6 +361,9 @@ class IMDClient:
     def _trate(self, rate):
         """
         Send a trate packet to the server to set transmission rate.
+
+
+        .. versionadded:: 0.3.0
         """
         trate = create_header_bytes(IMDHeaderType.IMD_TRATE, rate)
         self._conn.sendall(trate)
@@ -356,7 +378,10 @@ class IMDClient:
         self._conn.sendall(go)
         logger.debug("IMDClient: Sent go packet to server")
 
-        if self._continue_after_disconnect is not None and self._imdsinfo.version == 3:  
+        if (
+            self._continue_after_disconnect is not None
+            and self._imdsinfo.version == 3
+        ):
             wait_behavior = (int)(not self._continue_after_disconnect)
             wait_packet = create_header_bytes(
                 IMDHeaderType.IMD_WAIT, wait_behavior
@@ -607,6 +632,16 @@ class IMDProducerV2(BaseIMDProducer):
         # cache the last energies received
 
         # Consume any leading energy packets first, then handle positions.
+        # NOTE:
+        # IMDv3 implementations define a fixed per-frame packet order, but IMDv2
+        # implementations in simulation engines do not enforce ordering between
+        # packet types. Under stream connectivity issues, or in rare parallel
+        # execution cases in some engines (e.g. NAMD), an extra energy
+        # packet can slip through before the coordinate packet. We keep
+        # the last energy values seen and also warn when the leading energy packet
+        # count is more than 1, since energies may then be out of sync with the
+        # coordinates that follow. This behavior i.e. possible multiple consecutive
+        # IMD_ENERGIES packets before coordinates is an IMDv2-only exception.
         header = self._get_header()
         leading_energies = 0
         while header.type == IMDHeaderType.IMD_ENERGIES and header.length == 1:

--- a/imdclient/IMDClient.py
+++ b/imdclient/IMDClient.py
@@ -59,6 +59,7 @@ class IMDClient:
         If True, the client will attempt to change the simulation engine's waiting behavior to
         non-blocking after the client disconnects. If False, the client will attempt to change it
         to blocking. If None, the client will not attempt to change the simulation engine's behavior.
+        Only supported for IMDv3; must be ``None`` for IMDv2 connections.
     transmission_rate : int, optional [``None``]
         IMD transmission rate to be set after client send go signal. 
         This parameter is only set to the server when using IMDv2. Default behavior is to not set the transmission rate. 
@@ -92,6 +93,15 @@ class IMDClient:
         self._imdsinfo = self._await_IMD_handshake()
         self._multithreaded = multithreaded
         self._continue_after_disconnect = continue_after_disconnect
+
+        if (
+            self._imdsinfo.version == 2
+            and self._continue_after_disconnect is not None
+        ):
+            self._conn.close()
+            raise ValueError(
+                "IMDClient: continue_after_disconnect is only supported for IMDv3"
+            )
 
         if self._multithreaded:
             self._buf = IMDFrameBuffer(
@@ -346,7 +356,7 @@ class IMDClient:
         self._conn.sendall(go)
         logger.debug("IMDClient: Sent go packet to server")
 
-        if self._continue_after_disconnect is not None:
+        if self._continue_after_disconnect is not None and self._imdsinfo.version == 3:  
             wait_behavior = (int)(not self._continue_after_disconnect)
             wait_packet = create_header_bytes(
                 IMDHeaderType.IMD_WAIT, wait_behavior

--- a/imdclient/IMDProtocol.py
+++ b/imdclient/IMDProtocol.py
@@ -5,7 +5,6 @@ from typing import Union
 from dataclasses import dataclass
 import numpy as np
 
-
 IMDHEADERSIZE = 8
 IMDENERGYPACKETLENGTH = 40
 IMDBOXPACKETLENGTH = 36

--- a/imdclient/data/gromacs/md/gromacs_v2_nst1.mdp
+++ b/imdclient/data/gromacs/md/gromacs_v2_nst1.mdp
@@ -1,0 +1,51 @@
+title                   = PRODUCTION IN NPT
+ld-seed			= 1
+; Run parameters
+integrator              = md        ; leap-frog integrator
+nsteps                  = 100    ; 1 * 1000 = 1 ps
+dt                      = 0.001     ; 1 fs
+; Output control
+nstxout                 = 1      ; save coordinates every 1 fs
+nstvout                 = 1      ; save velocities every 1 fs
+nstfout                 = 1      ; save forces every 1 fs
+nstenergy               = 1      ; save energies every 1 fs
+nstlog                  = 10     
+; Center of mass (COM) motion
+nstcomm                 = 10        ; remove COM motion every 10 steps
+comm-mode               = Linear    ; remove only COM translation (liquids in PBC) 
+; Bond parameters
+continuation            = yes       ; first dynamics run
+constraint_algorithm    = lincs     ; holonomic constraints
+constraints             = all-bonds ; all bonds lengths are constrained
+lincs_iter              = 1         ; accuracy of LINCS
+lincs_order             = 4         ; also related to accuracy
+; Nonbonded settings
+cutoff-scheme           = Verlet    ; Buffered neighbor searching
+ns_type                 = grid      ; search neighboring grid cells
+nstlist                 = 10        ; 10 fs, largely irrelevant with Verlet
+rcoulomb                = 1.0       ; short-range electrostatic cutoff (in nm)
+rvdw                    = 1.0       ; short-range van der Waals cutoff (in nm)
+DispCorr                = EnerPres  ; account for cut-off vdW scheme
+; Electrostatics
+coulombtype             = PME       ; Particle Mesh Ewald for long-range electrostatics
+pme_order               = 4         ; cubic interpolation
+fourierspacing          = 0.12      ; grid spacing for FFT
+; Temperature coupling is on
+tcoupl                  = Nose-Hoover       ; good for production, after equilibration
+; we define separate thermostats for the solute and solvent (need to adapt)
+; see default groups defined by Gromacs for your system or define your own (make_ndx)
+tc-grps                 = Protein  SOL      ; the separate groups for the thermostats
+tau-t                   = 1.0      1.0      ; time constants for thermostats (ps)
+ref-t                   = 300      300      ; reference temperature for thermostats (K)
+; Pressure coupling is off
+pcoupl                  = Parrinello-Rahman ; good for production, after equilibration
+tau-p                   = 2.0               ; time constant for barostat (ps)
+compressibility         = 4.5e-5            ; compressibility (1/bar) set to water at ~300K
+ref-p                   = 1.0               ; reference pressure for barostat (bar)
+; Periodic boundary conditions
+pbc                     = xyz       ; 3-D PBC
+; Velocity generation
+gen_vel                 = no
+IMD-group               = System
+IMD-nst                 = 1
+IMD-version             = 2

--- a/imdclient/data/gromacs/md/gromacs_v2_nst8.mdp
+++ b/imdclient/data/gromacs/md/gromacs_v2_nst8.mdp
@@ -1,0 +1,51 @@
+title                   = PRODUCTION IN NPT
+ld-seed                 = 1
+; Run parameters
+integrator              = md        ; leap-frog integrator
+nsteps                  = 100    ; 1 * 1000 = 1 ps
+dt                      = 0.001     ; 1 fs
+; Output control
+nstxout                 = 8      ; save coordinates every 1 fs
+nstvout                 = 8      ; save velocities every 1 fs
+nstfout                 = 8
+nstenergy               = 8      ; save energies every 1 fs
+nstlog                  = 10      ; update log file every 1 ps
+; Center of mass (COM) motion
+nstcomm                 = 10        ; remove COM motion every 10 steps
+comm-mode               = Linear    ; remove only COM translation (liquids in PBC) 
+; Bond parameters
+continuation            = yes       ; first dynamics run
+constraint_algorithm    = lincs     ; holonomic constraints
+constraints             = all-bonds ; all bonds lengths are constrained
+lincs_iter              = 1         ; accuracy of LINCS
+lincs_order             = 4         ; also related to accuracy
+; Nonbonded settings
+cutoff-scheme           = Verlet    ; Buffered neighbor searching
+ns_type                 = grid      ; search neighboring grid cells
+nstlist                 = 10        ; 10 fs, largely irrelevant with Verlet
+rcoulomb                = 1.0       ; short-range electrostatic cutoff (in nm)
+rvdw                    = 1.0       ; short-range van der Waals cutoff (in nm)
+DispCorr                = EnerPres  ; account for cut-off vdW scheme
+; Electrostatics
+coulombtype             = PME       ; Particle Mesh Ewald for long-range electrostatics
+pme_order               = 4         ; cubic interpolation
+fourierspacing          = 0.12      ; grid spacing for FFT
+; Temperature coupling is on
+tcoupl                  = Nose-Hoover       ; good for production, after equilibration
+; we define separate thermostats for the solute and solvent (need to adapt)
+; see default groups defined by Gromacs for your system or define your own (make_ndx)
+tc-grps                 = Protein  SOL      ; the separate groups for the thermostats
+tau-t                   = 1.0      1.0      ; time constants for thermostats (ps)
+ref-t                   = 300      300      ; reference temperature for thermostats (K)
+; Pressure coupling is off
+pcoupl                  = Parrinello-Rahman ; good for production, after equilibration
+tau-p                   = 2.0               ; time constant for barostat (ps)
+compressibility         = 4.5e-5            ; compressibility (1/bar) set to water at ~300K
+ref-p                   = 1.0               ; reference pressure for barostat (bar)
+; Periodic boundary conditions
+pbc                     = xyz       ; 3-D PBC
+; Velocity generation
+gen_vel                 = no
+IMD-group               = System
+IMD-nst                 = 8
+IMD-version             = 2

--- a/imdclient/data/lammps/md/lammps_v2_nst_1.in
+++ b/imdclient/data/lammps/md/lammps_v2_nst_1.in
@@ -52,12 +52,12 @@ velocity all create 300 102939 dist gaussian mom yes rot yes
 fix 1 all nve 
 
 # Create source of truth trajectory
-dump h5md1 all h5md 8 lammps_trj.h5md position velocity force box yes
+dump h5md1 all h5md 1 lammps_trj.h5md position velocity force box yes
 dump_modify h5md1 unwrap no
 
 ## IMD settings
 # https://docs.lammps.org/fix_imd.html
-fix 2 all imd 8888 version 3 unwrap off nowait off trate 8 time on box on coordinates on velocities on forces on
+fix 2 all imd 8888 version 2 nowait off trate 1
 
 ## Run MD sim
 run 100

--- a/imdclient/data/lammps/md/lammps_v2_nst_1.in
+++ b/imdclient/data/lammps/md/lammps_v2_nst_1.in
@@ -52,7 +52,7 @@ velocity all create 300 102939 dist gaussian mom yes rot yes
 fix 1 all nve 
 
 # Create source of truth trajectory
-dump h5md1 all h5md 1 lammps_trj.h5md position velocity force box yes
+dump h5md1 all h5md 1 lammps_trj.h5md position
 dump_modify h5md1 unwrap no
 
 ## IMD settings

--- a/imdclient/data/lammps/md/lammps_v2_nst_8.in
+++ b/imdclient/data/lammps/md/lammps_v2_nst_8.in
@@ -52,7 +52,7 @@ velocity all create 300 102939 dist gaussian mom yes rot yes
 fix 1 all nve 
 
 # Create source of truth trajectory
-dump h5md1 all h5md 8 lammps_trj.h5md position velocity force box yes
+dump h5md1 all h5md 8 lammps_trj.h5md position
 dump_modify h5md1 unwrap no
 
 ## IMD settings

--- a/imdclient/data/lammps/md/lammps_v2_nst_8.in
+++ b/imdclient/data/lammps/md/lammps_v2_nst_8.in
@@ -57,7 +57,7 @@ dump_modify h5md1 unwrap no
 
 ## IMD settings
 # https://docs.lammps.org/fix_imd.html
-fix 2 all imd 8888 version 3 unwrap off nowait off trate 8 time on box on coordinates on velocities on forces on
+fix 2 all imd 8888 version 2 nowait off trate 8
 
 ## Run MD sim
 run 100

--- a/imdclient/data/lammps/md/lammps_v3_nst_1.in
+++ b/imdclient/data/lammps/md/lammps_v3_nst_1.in
@@ -57,7 +57,7 @@ dump_modify h5md1 unwrap no
 
 ## IMD settings
 # https://docs.lammps.org/fix_imd.html
-fix 2 all imd 8888 version 3 unwrap off nowait off
+fix 2 all imd 8888 version 3 unwrap off nowait off trate 1 time on box on coordinates on velocities on forces on
 
 ## Run MD sim
 run 100

--- a/imdclient/data/namd/md/namd_v2_nst_1.namd
+++ b/imdclient/data/namd/md/namd_v2_nst_1.namd
@@ -1,0 +1,52 @@
+# This is a test namd configuration file
+
+timestep	0.5
+numsteps	100
+structure	alanin.psf
+parameters	alanin.params
+coordinates	alanin.pdb
+exclude		scaled1-4
+1-4scaling	0.4
+outputname 	output[myReplica]
+margin		1.0
+stepspercycle   3
+temperature	0
+
+switching 	on
+switchdist	7.0
+cutoff		8.0
+pairlistdist 	9.0
+
+# Add box dimensions 
+cellBasisVector1  32.76  0.0   0.0
+cellBasisVector2   0.0  31.66  0.0
+cellBasisVector3   0.0   0.0  32.89
+
+DCDfile	alanin.dcd
+DCDfreq	1
+DCDUnitCell    yes
+velDcdFile	alanin.vel.dcd
+velDcdFreq	1
+forceDcdFile	alanin.force.dcd
+forceDcdFreq	1
+XSTFile     alanin.xst
+xstFreq		1
+
+#restartname	alanin.restart
+#restartfreq	10
+
+#langevin	on
+#langevinTemp	300.0
+#langevincol	O
+
+#constraints	on
+
+#fma		on
+
+seed		12345
+
+IMDon		yes
+IMDport		8888
+IMDfreq		1
+IMDwait		on
+IMDversion     2

--- a/imdclient/data/namd/md/namd_v2_nst_8.namd
+++ b/imdclient/data/namd/md/namd_v2_nst_8.namd
@@ -1,0 +1,52 @@
+# This is a test namd configuration file
+
+timestep	0.5
+numsteps	100
+structure	alanin.psf
+parameters	alanin.params
+coordinates	alanin.pdb
+exclude		scaled1-4
+1-4scaling	0.4
+outputname 	output[myReplica]
+margin		1.0
+stepspercycle   3
+temperature	0
+
+switching 	on
+switchdist	7.0
+cutoff		8.0
+pairlistdist 	9.0
+
+# Add box dimensions 
+cellBasisVector1  32.76  0.0   0.0
+cellBasisVector2   0.0  31.66  0.0
+cellBasisVector3   0.0   0.0  32.89
+
+DCDfile	alanin.dcd
+DCDfreq	8
+DCDUnitCell    yes
+velDcdFile	alanin.vel.dcd
+velDcdFreq	8
+forceDcdFile	alanin.force.dcd
+forceDcdFreq	8
+XSTFile     alanin.xst
+xstFreq		8
+
+#restartname	alanin.restart
+#restartfreq	10
+
+#langevin	on
+#langevinTemp	300.0
+#langevincol	O
+
+#constraints	on
+
+#fma		on
+
+seed		12345
+
+IMDon		yes
+IMDport		8888
+IMDfreq		8
+IMDwait		on
+IMDversion     2

--- a/imdclient/tests/base.py
+++ b/imdclient/tests/base.py
@@ -117,6 +117,10 @@ class IMDIntegrationTest:
         # a container
         time.sleep(30)
 
+        print("\n=== Container logs ===")
+        print(container.logs().decode("utf-8", errors="replace"))
+        print("=== End container logs ===\n")
+
         yield
         try:
             container.stop()

--- a/imdclient/tests/base.py
+++ b/imdclient/tests/base.py
@@ -10,6 +10,8 @@ from numpy.testing import (
 import docker
 import MDAnalysis as mda
 
+from MDAnalysis.transformations.wrap import wrap
+
 from .utils import get_free_port
 from .minimalreader import MinimalReader
 
@@ -132,6 +134,10 @@ class IMDIntegrationTest:
             pass
 
     @pytest.fixture()
+    def first_frame(self):
+        return 0
+
+    @pytest.fixture()
     def imd_u(self, docker_client, topol, tmp_path, port):
         n_atoms = mda.Universe(tmp_path / topol).atoms.n_atoms
         u = MinimalReader(
@@ -140,7 +146,7 @@ class IMDIntegrationTest:
         yield u
 
     @pytest.fixture()
-    def true_u(self, topol, traj, imd_u, tmp_path, docker_client):
+    def true_u(self, topol, traj, imd_u, tmp_path, docker_client, first_frame):
         # imd_u finishes when the IMD stream closes; wait for any post-processing in post_simulation_command
         # in the container before reading the reference trajectory from disk.
         docker_client.wait()
@@ -148,6 +154,9 @@ class IMDIntegrationTest:
             (tmp_path / topol),
             (tmp_path / traj),
         )
+        if not imd_u.imdsinfo.wrapped_coords:
+            u.trajectory.add_transformations(wrap(u.atoms, compound="atoms"))
+            imd_u._wrap_trajectory(u, first_frame)
         yield u
 
 

--- a/imdclient/tests/base.py
+++ b/imdclient/tests/base.py
@@ -70,6 +70,10 @@ class IMDIntegrationTest:
         return None
 
     @pytest.fixture()
+    def post_simulation_command(self):
+        return None
+
+    @pytest.fixture()
     def port(self):
         yield get_free_port()
 
@@ -80,6 +84,7 @@ class IMDIntegrationTest:
         input_files,
         setup_command,
         simulation_command,
+        post_simulation_command,
         port,
         container_name,
     ):
@@ -100,6 +105,8 @@ class IMDIntegrationTest:
             cmdstring += " && " + setup_command
 
         cmdstring += " && " + simulation_command
+        if post_simulation_command is not None:
+            cmdstring += " && " + post_simulation_command
 
         # Start the container, mount tmp_path, run simulation
         container = docker_client.containers.run(
@@ -117,11 +124,8 @@ class IMDIntegrationTest:
         # a container
         time.sleep(30)
 
-        print("\n=== Container logs ===")
-        print(container.logs().decode("utf-8", errors="replace"))
-        print("=== End container logs ===\n")
+        yield container
 
-        yield
         try:
             container.stop()
         except docker.errors.NotFound:
@@ -136,12 +140,16 @@ class IMDIntegrationTest:
         yield u
 
     @pytest.fixture()
-    def true_u(self, topol, traj, imd_u, tmp_path):
+    def true_u(self, topol, traj, imd_u, tmp_path, docker_client):
+        # imd_u finishes when the IMD stream closes; wait for any post-processing in post_simulation_command
+        # in the container before reading the reference trajectory from disk.
+        docker_client.wait()
         u = mda.Universe(
             (tmp_path / topol),
             (tmp_path / traj),
         )
         yield u
+
 
 class IMDv3IntegrationTest(IMDIntegrationTest):
 
@@ -239,6 +247,7 @@ class IMDv3IntegrationTest(IMDIntegrationTest):
             atom_style="id type x y z",
         ).atoms.n_atoms
         u = MinimalReader(f"imd://localhost:{port}", n_atoms=n_atoms)
+
 
 class IMDv2IntegrationTest(IMDIntegrationTest):
 

--- a/imdclient/tests/base.py
+++ b/imdclient/tests/base.py
@@ -59,7 +59,7 @@ def assert_allclose_with_logging(a, b, rtol=1e-07, atol=0, equal_nan=False):
         print("All values are within tolerance.")
 
 
-class IMDv3IntegrationTest:
+class IMDIntegrationTest:
 
     @pytest.fixture()
     def container_name(self):
@@ -138,6 +138,8 @@ class IMDv3IntegrationTest:
             (tmp_path / traj),
         )
         yield u
+
+class IMDv3IntegrationTest(IMDIntegrationTest):
 
     def test_compare_imd_to_true_traj(self, imd_u, true_u, first_frame, dt):
         for i in range(first_frame, len(true_u.trajectory)):
@@ -233,3 +235,14 @@ class IMDv3IntegrationTest:
             atom_style="id type x y z",
         ).atoms.n_atoms
         u = MinimalReader(f"imd://localhost:{port}", n_atoms=n_atoms)
+
+class IMDv2IntegrationTest(IMDIntegrationTest):
+
+    def test_compare_imd_to_true_traj(self, imd_u, true_u, first_frame, dt):
+        for i in range(first_frame, len(true_u.trajectory)):
+
+            assert_allclose_with_logging(
+                true_u.trajectory[i].positions,
+                imd_u.trajectory[i - first_frame].positions,
+                atol=1e-03,
+            )

--- a/imdclient/tests/base.py
+++ b/imdclient/tests/base.py
@@ -138,10 +138,17 @@ class IMDIntegrationTest:
         return 0
 
     @pytest.fixture()
-    def imd_u(self, docker_client, topol, tmp_path, port):
+    def imd_nst(self):
+        return None
+
+    @pytest.fixture()
+    def imd_u(self, docker_client, topol, tmp_path, port, imd_nst):
         n_atoms = mda.Universe(tmp_path / topol).atoms.n_atoms
         u = MinimalReader(
-            f"imd://localhost:{port}", n_atoms=n_atoms, process_stream=True
+            f"imd://localhost:{port}",
+            n_atoms=n_atoms,
+            process_stream=True,
+            transmission_rate=imd_nst,
         )
         yield u
 

--- a/imdclient/tests/base.py
+++ b/imdclient/tests/base.py
@@ -238,7 +238,7 @@ class IMDv3IntegrationTest(IMDIntegrationTest):
 
 class IMDv2IntegrationTest(IMDIntegrationTest):
 
-    def test_compare_imd_to_true_traj(self, imd_u, true_u, first_frame, dt):
+    def test_compare_imd_to_true_traj(self, imd_u, true_u, first_frame):
         for i in range(first_frame, len(true_u.trajectory)):
 
             assert_allclose_with_logging(

--- a/imdclient/tests/datafiles.py
+++ b/imdclient/tests/datafiles.py
@@ -10,17 +10,23 @@ Use as ::
 
 __all__ = [
     "LAMMPS_TOPOL",
-    "LAMMPS_IN_NST_1",
-    "LAMMPS_IN_NST_8",
+    "LAMMPS_IN_V3_NST_1",
+    "LAMMPS_IN_V3_NST_8",
+    "LAMMPS_IN_V2_NST_1",
+    "LAMMPS_IN_V2_NST_8",
     "GROMACS_TRAJ",
     "GROMACS_MDP",
     "GROMACS_TOP",
     "GROMACS_GRO",
-    "GROMACS_MDP_NST_1",
-    "GROMACS_MDP_NST_8",
+    "GROMACS_MDP_V3_NST_1",
+    "GROMACS_MDP_V3_NST_8",
+    "GROMACS_MDP_V2_NST_1",
+    "GROMACS_MDP_V2_NST_8",
     "NAMD_TOPOL",
-    "NAMD_CONF_NST_1",
-    "NAMD_CONF_NST_8",
+    "NAMD_CONF_V3_NST_1",
+    "NAMD_CONF_V3_NST_8",
+    "NAMD_CONF_V2_NST_1",
+    "NAMD_CONF_V2_NST_8",
     "NAMD_PARAMS",
     "NAMD_PSF",
 ]
@@ -31,26 +37,48 @@ from pathlib import Path
 _data_ref = resources.files("imdclient.data")
 
 LAMMPS_TOPOL = (_data_ref / "lammps" / "md" / "lammps_topol.data").as_posix()
-LAMMPS_IN_NST_1 = (
+LAMMPS_IN_V3_NST_1 = (
     _data_ref / "lammps" / "md" / "lammps_v3_nst_1.in"
 ).as_posix()
-LAMMPS_IN_NST_8 = (
+LAMMPS_IN_V3_NST_8 = (
     _data_ref / "lammps" / "md" / "lammps_v3_nst_8.in"
+).as_posix()
+LAMMPS_IN_V2_NST_1 = (
+    _data_ref / "lammps" / "md" / "lammps_v2_nst_1.in"
+).as_posix()
+LAMMPS_IN_V2_NST_8 = (
+    _data_ref / "lammps" / "md" / "lammps_v2_nst_8.in"
 ).as_posix()
 
 
 GROMACS_GRO = (_data_ref / "gromacs" / "md" / "gromacs_struct.gro").as_posix()
-GROMACS_MDP_NST_1 = (
+GROMACS_MDP_V3_NST_1 = (
     _data_ref / "gromacs" / "md" / "gromacs_v3_nst1.mdp"
 ).as_posix()
-GROMACS_MDP_NST_8 = (
+GROMACS_MDP_V3_NST_8 = (
     _data_ref / "gromacs" / "md" / "gromacs_v3_nst8.mdp"
+).as_posix()
+GROMACS_MDP_V2_NST_1 = (
+    _data_ref / "gromacs" / "md" / "gromacs_v2_nst1.mdp"
+).as_posix()
+GROMACS_MDP_V2_NST_8 = (
+    _data_ref / "gromacs" / "md" / "gromacs_v2_nst8.mdp"
 ).as_posix()
 GROMACS_TOP = (_data_ref / "gromacs" / "md" / "gromacs_v3.top").as_posix()
 
 NAMD_TOPOL = (_data_ref / "namd" / "md" / "alanin.pdb").as_posix()
-NAMD_CONF_NST_1 = (_data_ref / "namd" / "md" / "namd_v3_nst_1.namd").as_posix()
-NAMD_CONF_NST_8 = (_data_ref / "namd" / "md" / "namd_v3_nst_8.namd").as_posix()
+NAMD_CONF_V3_NST_1 = (
+    _data_ref / "namd" / "md" / "namd_v3_nst_1.namd"
+).as_posix()
+NAMD_CONF_V3_NST_8 = (
+    _data_ref / "namd" / "md" / "namd_v3_nst_8.namd"
+).as_posix()
+NAMD_CONF_V2_NST_1 = (
+    _data_ref / "namd" / "md" / "namd_v2_nst_1.namd"
+).as_posix()
+NAMD_CONF_V2_NST_8 = (
+    _data_ref / "namd" / "md" / "namd_v2_nst_8.namd"
+).as_posix()
 NAMD_PARAMS = (_data_ref / "namd" / "md" / "alanin.params").as_posix()
 NAMD_PSF = (_data_ref / "namd" / "md" / "alanin.psf").as_posix()
 

--- a/imdclient/tests/minimalreader.py
+++ b/imdclient/tests/minimalreader.py
@@ -50,6 +50,10 @@ class MinimalReader:
         if process_stream:
             self._process_stream()
 
+    @property
+    def imdsinfo(self):
+        return self._imdclient.get_imdsessioninfo()
+
     def _read_next_frame(self):
         try:
             imd_frame = self._imdclient.get_imdframe()

--- a/imdclient/tests/minimalreader.py
+++ b/imdclient/tests/minimalreader.py
@@ -58,13 +58,13 @@ class MinimalReader:
         self.imd_frame = imd_frame
 
         # Modify the box dimensions to be triclinic
-        self._modify_box_dimesions()
+        self._modify_box_dimensions()
 
         logger.debug(f"MinimalReader: Loaded frame {self._frame}")
 
         return self.imd_frame
 
-    def _modify_box_dimesions(self):
+    def _modify_box_dimensions(self):
         if self.imd_frame.box is None:
             self.imd_frame.dimensions = None
             return

--- a/imdclient/tests/minimalreader.py
+++ b/imdclient/tests/minimalreader.py
@@ -1,7 +1,9 @@
 import logging
 import copy
 
+import numpy as np
 from MDAnalysis.coordinates import core
+from MDAnalysis.lib import distances
 
 from imdclient.IMDClient import IMDClient
 from imdclient.utils import parse_host_port
@@ -81,6 +83,27 @@ class MinimalReader:
                 )
             except EOFError:
                 break
+
+    def _wrap_frame(self, frame, box):
+        if box is None:
+            return
+        frame.positions = distances.apply_PBC(
+            np.asarray(frame.positions, dtype=np.float32),
+            box,
+        )
+
+    def _wrap_trajectory(self, true_u=None, first_frame=0):
+        """Wrap each stored IMD frame into the primary box (per atom)."""
+        if true_u is None:
+            for frame in self.trajectory:
+                self._wrap_frame(frame, frame.dimensions)
+            return
+
+        for i in range(first_frame, len(true_u.trajectory)):
+            self._wrap_frame(
+                self.trajectory[i - first_frame],
+                true_u.trajectory[i].dimensions,
+            )
 
     def close(self):
         """Gracefully shut down the reader. Stops the producer thread."""

--- a/imdclient/tests/minimalreader.py
+++ b/imdclient/tests/minimalreader.py
@@ -65,6 +65,9 @@ class MinimalReader:
         return self.imd_frame
 
     def _modify_box_dimesions(self):
+        if self.imd_frame.box is None:
+            self.imd_frame.dimensions = None
+            return
         self.imd_frame.dimensions = core.triclinic_box(*self.imd_frame.box)
 
     def _process_stream(self):

--- a/imdclient/tests/server.py
+++ b/imdclient/tests/server.py
@@ -37,7 +37,7 @@ class InThreadIMDServer:
     @property
     def port(self):
         """Get the port the server is bound to.
-        
+
         Returns:
             int: The port number, or None if not bound yet.
         """
@@ -47,7 +47,9 @@ class InThreadIMDServer:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.bind((host, 0))  # Bind to port 0 to get a free port
         self._bound_port = s.getsockname()[1]  # Store the actual bound port
-        logger.debug(f"InThreadIMDServer: Listening on {host}:{self._bound_port}")
+        logger.debug(
+            f"InThreadIMDServer: Listening on {host}:{self._bound_port}"
+        )
         s.listen(60)
         self.listen_socket = s
 

--- a/imdclient/tests/server.py
+++ b/imdclient/tests/server.py
@@ -202,6 +202,10 @@ class InThreadIMDServer:
                 f"Expected packet length {expected_length}, got {header.length}"
             )
 
+    def expect_no_packet(self, timeout=0):
+        if sock_contains_data(self.conn, timeout):
+            raise ValueError("Expected no packet here")
+
     def disconnect(self):
         self.conn.shutdown(socket.SHUT_RD)
         self.conn.close()

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -77,3 +77,13 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
     @pytest.fixture(params=[GROMACS_MDP_V2_NST_1, GROMACS_MDP_V2_NST_8])
     def mdp(self, request):
         return request.param
+
+    @pytest.fixture()
+    def simulation_command(self):
+        # Run mdrun, then do molecule-whole PBC treatment from the trajectory
+        # so it matches the mol-whole coordinates sent by default in GROMACS IMD v2.
+        return (
+            "gmx mdrun -s topol.tpr -o ci.trr -imdport 8888 -imdwait"
+            " && echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc mol"
+            " && mv ci_nopbc.trr ci.trr"
+        )

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -84,8 +84,8 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
         # so it matches the mol-whole coordinates sent by default in GROMACS IMD v2.
         return (
             f"gmx mdrun -s topol.tpr -o ci.trr -imdport 8888 -imdwait && "
-            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_whole.trr -pbc mol && "
+            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_whole.trr -pbc whole && "
             f"mv ci_whole.trr ci.trr && "
-            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc nojump && "
+            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc mol && "
             f"mv ci_nopbc.trr ci.trr"
         )

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -83,7 +83,9 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
         # Run mdrun, then do molecule-whole PBC treatment from the trajectory
         # so it matches the mol-whole coordinates sent by default in GROMACS IMD v2.
         return (
-            "gmx mdrun -s topol.tpr -o ci.trr -imdport 8888 -imdwait"
-            " && echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc mol"
-            " && mv ci_nopbc.trr ci.trr"
+            f"gmx mdrun -s topol.tpr -o ci.trr -imdport 8888 -imdwait && "
+            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_whole.trr -pbc mol && "
+            f"mv ci_whole.trr ci.trr && "
+            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc nojump && "
+            f"mv ci_nopbc.trr ci.trr"
         )

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -80,10 +80,8 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
 
     @pytest.fixture()
     def post_simulation_command(self):
-        # Match the mol-whole coordinates sent by default in GROMACS IMD v2.
+        # Match GROMACS IMD v2 mol-shifted whole coords using pbc whole.
         return (
             "echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_whole.trr -pbc whole && "
-            "mv ci_whole.trr ci.trr && "
-            "echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc mol && "
-            "mv ci_nopbc.trr ci.trr"
+            "mv ci_whole.trr ci.trr"
         )

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import re
 
 import pytest
-import MDAnalysis as mda
 
 from .base import IMDv2IntegrationTest, IMDv3IntegrationTest
 from .datafiles import (
@@ -57,14 +56,6 @@ class IMDGromacsTest:
                     return float(match.group(1))
         raise ValueError(f"No dt found in {mdp}")
 
-    # @pytest.fixture()
-    # def match_string(self):
-    #     return "IMD: Will wait until I have a connection and IMD_GO orders."
-
-    @pytest.fixture()
-    def first_frame(self):
-        return 0
-
 
 class TestIMDv3Gromacs(IMDGromacsTest, IMDv3IntegrationTest):
 
@@ -78,13 +69,3 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
     @pytest.fixture(params=[GROMACS_MDP_V2_NST_1, GROMACS_MDP_V2_NST_8])
     def mdp(self, request):
         return request.param
-
-    @pytest.fixture()
-    def true_u(self, topol, traj, imd_u, tmp_path, docker_client, first_frame):
-        docker_client.wait()
-        u = mda.Universe(
-            (tmp_path / topol),
-            (tmp_path / traj),
-        )
-        imd_u._wrap_trajectory(u, first_frame)
-        yield u

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -24,8 +24,7 @@ logger.addHandler(file_handler)
 logger.setLevel(logging.DEBUG)
 
 
-class TestIMDGromacs:
-    __test__ = False
+class IMDGromacsTest:
 
     @pytest.fixture()
     def setup_command(self, mdp):
@@ -66,14 +65,14 @@ class TestIMDGromacs:
         return 0
 
 
-class TestIMDv3Gromacs(TestIMDGromacs, IMDv3IntegrationTest):
+class TestIMDv3Gromacs(IMDGromacsTest, IMDv3IntegrationTest):
 
     @pytest.fixture(params=[GROMACS_MDP_V3_NST_1, GROMACS_MDP_V3_NST_8])
     def mdp(self, request):
         return request.param
 
 
-class TestIMDv2Gromacs(TestIMDGromacs, IMDv2IntegrationTest):
+class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
 
     @pytest.fixture(params=[GROMACS_MDP_V2_NST_1, GROMACS_MDP_V2_NST_8])
     def mdp(self, request):

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -79,13 +79,11 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
         return request.param
 
     @pytest.fixture()
-    def simulation_command(self):
-        # Run mdrun, then do molecule-whole PBC treatment from the trajectory
-        # so it matches the mol-whole coordinates sent by default in GROMACS IMD v2.
+    def post_simulation_command(self):
+        # Match the mol-whole coordinates sent by default in GROMACS IMD v2.
         return (
-            f"gmx mdrun -s topol.tpr -o ci.trr -imdport 8888 -imdwait && "
-            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_whole.trr -pbc whole && "
-            f"mv ci_whole.trr ci.trr && "
-            f"echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc mol && "
-            f"mv ci_nopbc.trr ci.trr"
+            "echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_whole.trr -pbc whole && "
+            "mv ci_whole.trr ci.trr && "
+            "echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_nopbc.trr -pbc mol && "
+            "mv ci_nopbc.trr ci.trr"
         )

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -69,3 +69,13 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
     @pytest.fixture(params=[GROMACS_MDP_V2_NST_1, GROMACS_MDP_V2_NST_8])
     def mdp(self, request):
         return request.param
+
+    @pytest.fixture()
+    def imd_nst(self, mdp):
+        pattern = re.compile(r"^\s*IMD-nst\s*=\s*(\S+)")
+        with open(mdp, "r") as file:
+            for line in file:
+                match = pattern.match(line)
+                if match:
+                    return int(match.group(1))
+        raise ValueError(f"No IMD-nst found in {mdp}")

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import re
 
 import pytest
+import MDAnalysis as mda
 
 from .base import IMDv2IntegrationTest, IMDv3IntegrationTest
 from .datafiles import (
@@ -79,9 +80,11 @@ class TestIMDv2Gromacs(IMDGromacsTest, IMDv2IntegrationTest):
         return request.param
 
     @pytest.fixture()
-    def post_simulation_command(self):
-        # Match GROMACS IMD v2 mol-shifted whole coords using pbc whole.
-        return (
-            "echo '0' | gmx trjconv -f ci.trr -s topol.tpr -o ci_whole.trr -pbc whole && "
-            "mv ci_whole.trr ci.trr"
+    def true_u(self, topol, traj, imd_u, tmp_path, docker_client, first_frame):
+        docker_client.wait()
+        u = mda.Universe(
+            (tmp_path / topol),
+            (tmp_path / traj),
         )
+        imd_u._wrap_trajectory(u, first_frame)
+        yield u

--- a/imdclient/tests/test_gromacs.py
+++ b/imdclient/tests/test_gromacs.py
@@ -4,12 +4,14 @@ import re
 
 import pytest
 
-from .base import IMDv3IntegrationTest
+from .base import IMDv2IntegrationTest, IMDv3IntegrationTest
 from .datafiles import (
     GROMACS_GRO,
     GROMACS_TOP,
-    GROMACS_MDP_NST_1,
-    GROMACS_MDP_NST_8,
+    GROMACS_MDP_V3_NST_1,
+    GROMACS_MDP_V3_NST_8,
+    GROMACS_MDP_V2_NST_1,
+    GROMACS_MDP_V2_NST_8,
 )
 
 logger = logging.getLogger("imdclient.IMDClient")
@@ -22,11 +24,8 @@ logger.addHandler(file_handler)
 logger.setLevel(logging.DEBUG)
 
 
-class TestIMDv3Gromacs(IMDv3IntegrationTest):
-
-    @pytest.fixture(params=[GROMACS_MDP_NST_1, GROMACS_MDP_NST_8])
-    def mdp(self, request):
-        return request.param
+class TestIMDGromacs:
+    __test__ = False
 
     @pytest.fixture()
     def setup_command(self, mdp):
@@ -65,3 +64,17 @@ class TestIMDv3Gromacs(IMDv3IntegrationTest):
     @pytest.fixture()
     def first_frame(self):
         return 0
+
+
+class TestIMDv3Gromacs(TestIMDGromacs, IMDv3IntegrationTest):
+
+    @pytest.fixture(params=[GROMACS_MDP_V3_NST_1, GROMACS_MDP_V3_NST_8])
+    def mdp(self, request):
+        return request.param
+
+
+class TestIMDv2Gromacs(TestIMDGromacs, IMDv2IntegrationTest):
+
+    @pytest.fixture(params=[GROMACS_MDP_V2_NST_1, GROMACS_MDP_V2_NST_8])
+    def mdp(self, request):
+        return request.param

--- a/imdclient/tests/test_imdclient.py
+++ b/imdclient/tests/test_imdclient.py
@@ -393,7 +393,9 @@ class TestIMDClientV2(IMDClientTest):
         with pytest.raises(EOFError) as exc_info:
             client.get_imdframe()
 
-        assert f"Unexpected packet type {packet_type.name}" in str(exc_info.value)
+        assert f"Unexpected packet type {packet_type.name}" in str(
+            exc_info.value
+        )
 
 
 class TestIMDClientV3ContextManager(IMDClientTest):

--- a/imdclient/tests/test_imdclient.py
+++ b/imdclient/tests/test_imdclient.py
@@ -2,22 +2,25 @@
 
 import logging
 
-import pytest
-from numpy.testing import (
-    assert_allclose,
-)
 import MDAnalysis as mda
 from MDAnalysisTests.datafiles import (
-    COORDINATES_TOPOLOGY,
     COORDINATES_H5MD,
+    COORDINATES_TOPOLOGY,
 )
+from numpy.testing import assert_allclose
+import pytest
 
-from imdclient.IMDClient import imdframe_memsize, IMDClient
-from imdclient.IMDProtocol import IMDHeaderType
-from .utils import (
-    create_default_imdsinfo_v3,
+from imdclient.IMDClient import IMDClient, imdframe_memsize
+from imdclient.IMDProtocol import (
+    IMDHeaderType,
+    create_energy_bytes,
+    create_header_bytes,
 )
 from .server import InThreadIMDServer
+from .utils import (
+    create_default_imdsinfo_v2,
+    create_default_imdsinfo_v3,
+)
 
 
 logger = logging.getLogger("imdclient.IMDClient")
@@ -43,15 +46,14 @@ IMDENERGYKEYS = [
 ]
 
 
-class TestIMDClientV3:
-
+class IMDClientTest:
     @pytest.fixture
     def universe(self):
         return mda.Universe(COORDINATES_TOPOLOGY, COORDINATES_H5MD)
 
     @pytest.fixture
     def imdsinfo(self):
-        return create_default_imdsinfo_v3()
+        return create_default_imdsinfo_v2()
 
     @pytest.fixture
     def server_client_two_frame_buf(self, universe, imdsinfo):
@@ -59,7 +61,7 @@ class TestIMDClientV3:
         server.set_imdsessioninfo(imdsinfo)
         server.handshake_sequence("localhost", first_frame=False)
         client = IMDClient(
-            f"localhost",
+            "localhost",
             server.port,
             universe.trajectory.n_atoms,
             buffer_size=imdframe_memsize(universe.trajectory.n_atoms, imdsinfo)
@@ -76,11 +78,7 @@ class TestIMDClientV3:
         imdsinfo.endianness = request.param
         server.set_imdsessioninfo(imdsinfo)
         server.handshake_sequence("localhost", first_frame=False)
-        client = IMDClient(
-            f"localhost",
-            server.port,
-            universe.atoms.n_atoms,
-        )
+        client = IMDClient("localhost", server.port, universe.atoms.n_atoms)
         server.join_accept_thread()
         yield server, client
         client.stop()
@@ -91,30 +89,58 @@ class TestIMDClientV3:
         server = InThreadIMDServer(universe.trajectory)
         server.set_imdsessioninfo(imdsinfo)
         server.handshake_sequence("localhost", first_frame=False)
-        client = IMDClient(
-            f"localhost",
-            server.port,
-            universe.atoms.n_atoms + 1,
-        )
+        client = IMDClient("localhost", server.port, universe.atoms.n_atoms + 1)
         server.join_accept_thread()
         yield server, client
         client.stop()
         server.cleanup()
 
-    def test_traj_unchanged(self, server_client, universe):
+    def test_traj_unchanged(self, server_client, imdsinfo, universe):
         server, client = server_client
         server.send_frames(0, 5)
         for i in range(5):
             imdf = client.get_imdframe()
-            assert_allclose(universe.trajectory[i].time, imdf.time)
-            assert_allclose(universe.trajectory[i].dt, imdf.dt)
-            assert_allclose(universe.trajectory[i].data["step"], imdf.step)
-            assert_allclose(universe.trajectory[i].positions, imdf.positions)
-            assert_allclose(universe.trajectory[i].velocities, imdf.velocities)
-            assert_allclose(universe.trajectory[i].forces, imdf.forces)
-            assert_allclose(
-                universe.trajectory[i].triclinic_dimensions, imdf.box
-            )
+            if imdsinfo.time:
+                assert_allclose(universe.trajectory[i].time, imdf.time)
+                assert_allclose(universe.trajectory[i].dt, imdf.dt)
+                assert_allclose(universe.trajectory[i].data["step"], imdf.step)
+            if imdsinfo.box:
+                assert_allclose(
+                    universe.trajectory[i].triclinic_dimensions, imdf.box
+                )
+            if imdsinfo.positions:
+                assert_allclose(
+                    universe.trajectory[i].positions, imdf.positions
+                )
+            if imdsinfo.velocities:
+                assert_allclose(
+                    universe.trajectory[i].velocities, imdf.velocities
+                )
+            if imdsinfo.forces:
+                assert_allclose(universe.trajectory[i].forces, imdf.forces)
+
+    def test_incorrect_atom_count(
+        self, server_client_incorrect_atoms, universe
+    ):
+        server, client = server_client_incorrect_atoms
+
+        server.send_frame(0)
+
+        with pytest.raises(EOFError) as exc_info:
+            client.get_imdframe()
+
+        error_msg = str(exc_info.value)
+        assert (
+            f"Expected n_atoms value {universe.atoms.n_atoms + 1}" in error_msg
+        )
+        assert f"got {universe.atoms.n_atoms}" in error_msg
+        assert "Ensure you are using the correct topology file" in error_msg
+
+
+class TestIMDClientV3(IMDClientTest):
+    @pytest.fixture
+    def imdsinfo(self):
+        return create_default_imdsinfo_v3()
 
     def test_pause_resume_continue(self, server_client_two_frame_buf):
         server, client = server_client_two_frame_buf
@@ -168,35 +194,158 @@ class TestIMDClientV3:
         server.set_imdsessioninfo(imdsinfo)
         server.handshake_sequence("localhost", first_frame=False)
         client = IMDClient(
-            f"localhost",
+            "localhost",
             server.port,
             universe.trajectory.n_atoms,
             continue_after_disconnect=cont,
         )
         server.join_accept_thread()
         server.expect_packet(
-            IMDHeaderType.IMD_WAIT, expected_length=(int)(not cont)
+            IMDHeaderType.IMD_WAIT, expected_length=int(not cont)
         )
 
-    def test_incorrect_atom_count(self, server_client_incorrect_atoms, universe):
-        server, client = server_client_incorrect_atoms
-        
-        server.send_frame(0)
-        
-        with pytest.raises(EOFError) as exc_info:
+
+class TestIMDClientV2(IMDClientTest):
+    def test_pause_pause_continue(self, server_client_two_frame_buf):
+        server, client = server_client_two_frame_buf
+        server.send_frames(0, 2)
+        # Client's buffer is filled; client should send pause.
+        server.expect_packet(IMDHeaderType.IMD_PAUSE)
+        # Empty buffer.
+        client.get_imdframe()
+        # Only the second call actually frees buffer memory.
+        client.get_imdframe()
+        # IMDv2 uses IMD_PAUSE for both pause and unpause.
+        server.expect_packet(IMDHeaderType.IMD_PAUSE)
+        server.send_frame(1)
+        client.get_imdframe()
+
+    def test_pause_pause_disconnect(self, server_client_two_frame_buf):
+        """Client pauses because buffer is full, empties buffer and attempts to
+        unpause with a second IMD_PAUSE, but simulation has already ended and
+        raises EOF."""
+        server, client = server_client_two_frame_buf
+        server.send_frames(0, 2)
+        server.expect_packet(IMDHeaderType.IMD_PAUSE)
+        client.get_imdframe()
+        client.get_imdframe()
+        # IMDv2 uses IMD_PAUSE for both pause and unpause.
+        server.expect_packet(IMDHeaderType.IMD_PAUSE)
+        # Simulation is over; client should raise EOF.
+        server.disconnect()
+        with pytest.raises(EOFError):
             client.get_imdframe()
-        
-        error_msg = str(exc_info.value)
-        assert f"Expected n_atoms value {universe.atoms.n_atoms + 1}" in error_msg
-        assert f"got {universe.atoms.n_atoms}" in error_msg
-        assert "Ensure you are using the correct topology file" in error_msg
+
+    def test_pause_pause_no_disconnect(self, server_client_two_frame_buf):
+        """Client pauses because buffer is full, empties buffer and attempts to
+        unpause with a second IMD_PAUSE, but simulation has already ended (without
+        disconnecting) and raises EOF."""
+        server, client = server_client_two_frame_buf
+        server.send_frames(0, 2)
+        server.expect_packet(IMDHeaderType.IMD_PAUSE)
+        client.get_imdframe()
+        client.get_imdframe()
+        # IMDv2 uses IMD_PAUSE for both pause and unpause.
+        server.expect_packet(IMDHeaderType.IMD_PAUSE)
+        # Simulation is over; client should raise EOF.
+        with pytest.raises(EOFError):
+            client.get_imdframe()
+        # Server should receive disconnect from client (though it doesn't have to do anything).
+        server.expect_packet(IMDHeaderType.IMD_DISCONNECT)
+
+    def test_reads_multiple_leading_energies_before_coords(
+        self, server_client, caplog
+    ):
+        server, client = server_client
+
+        with caplog.at_level(logging.WARNING, logger="imdclient.IMDClient"):
+            endianness = client.get_imdsessioninfo().endianness
+            # Send >3 leading energy packets before coordinates.
+            for i in range(4):
+                energy_header = create_header_bytes(
+                    IMDHeaderType.IMD_ENERGIES, 1
+                )
+                energies = create_energy_bytes(
+                    i,
+                    i + 1,
+                    i + 2,
+                    i + 3,
+                    i + 4,
+                    i + 5,
+                    i + 6,
+                    i + 7,
+                    i + 8,
+                    i + 9,
+                    endianness,
+                )
+                server.conn.sendall(energy_header + energies)
+
+            pos_header = create_header_bytes(
+                IMDHeaderType.IMD_FCOORDS, server.traj.n_atoms
+            )
+            pos = universe_frame0 = server.traj[0].positions
+            pos_bytes = pos.astype(f"{endianness}f", copy=False).tobytes()
+            server.conn.sendall(pos_header + pos_bytes)
+
+            imdf = client.get_imdframe()
+
+        assert imdf.energies is not None
+        assert imdf.energies["step"] == 3
+        assert_allclose(universe_frame0, imdf.positions)
+        assert any(
+            "Received 4 leading IMDv2 energy packets" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_reads_no_leading_energy_packets(self, server_client, caplog):
+        server, client = server_client
+
+        with caplog.at_level(logging.WARNING, logger="imdclient.IMDClient"):
+            endianness = client.get_imdsessioninfo().endianness
+            # Send coords only, no leading energy packet.
+            pos_header = create_header_bytes(
+                IMDHeaderType.IMD_FCOORDS, server.traj.n_atoms
+            )
+            pos = server.traj[0].positions
+            pos_bytes = pos.astype(f"{endianness}f", copy=False).tobytes()
+            server.conn.sendall(pos_header + pos_bytes)
+
+            imdf = client.get_imdframe()
+
+        assert imdf.energies is None
+        assert_allclose(pos, imdf.positions)
+        assert any(
+            "Received 0 leading IMDv2 energy packets" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_uses_previous_energies_when_frame_has_coords_only(
+        self, server_client
+    ):
+        server, client = server_client
+
+        # First frame with energies sets the cache.
+        server.send_frame(0)
+        first = client.get_imdframe()
+        assert first.energies is not None
+        prev_step = first.energies["step"]
+
+        # Second frame: send only coords; should reuse previous energies.
+        endianness = client.get_imdsessioninfo().endianness
+        pos_header = create_header_bytes(
+            IMDHeaderType.IMD_FCOORDS, server.traj.n_atoms
+        )
+        pos = server.traj[1].positions
+        pos_bytes = pos.astype(f"{endianness}f", copy=False).tobytes()
+        server.conn.sendall(pos_header + pos_bytes)
+
+        second = client.get_imdframe()
+        assert second.energies is not None
+        assert second.energies["step"] == prev_step
+        assert_allclose(pos, second.positions)
 
 
-class TestIMDClientV3ContextManager:
-    @pytest.fixture
-    def universe(self):
-        return mda.Universe(COORDINATES_TOPOLOGY, COORDINATES_H5MD)
-
+class TestIMDClientV3ContextManager(IMDClientTest):
     @pytest.fixture
     def imdsinfo(self):
         return create_default_imdsinfo_v3()
@@ -213,13 +362,10 @@ class TestIMDClientV3ContextManager:
 
         i = 0
         with IMDClient(
-            "localhost",
-            server.port,
-            universe.trajectory.n_atoms,
+            "localhost", server.port, universe.trajectory.n_atoms
         ) as client:
             server.send_frames(0, 5)
             while i < 5:
-
                 imdf = client.get_imdframe()
                 assert_allclose(universe.trajectory[i].time, imdf.time)
                 assert_allclose(universe.trajectory[i].dt, imdf.dt)

--- a/imdclient/tests/test_imdclient.py
+++ b/imdclient/tests/test_imdclient.py
@@ -204,8 +204,39 @@ class TestIMDClientV3(IMDClientTest):
             IMDHeaderType.IMD_WAIT, expected_length=int(not cont)
         )
 
+    def test_trate_not_sent_for_v3(self, universe, imdsinfo):
+        server = InThreadIMDServer(universe.trajectory)
+        server.set_imdsessioninfo(imdsinfo)
+        server.handshake_sequence("localhost", first_frame=False)
+        client = IMDClient(
+            "localhost",
+            server.port,
+            universe.atoms.n_atoms,
+            transmission_rate=8,
+        )
+        server.join_accept_thread()
+        server.expect_no_packet()
+        client.stop()
+        server.cleanup()
+
 
 class TestIMDClientV2(IMDClientTest):
+    @pytest.mark.parametrize("rate", [1, 8])
+    def test_trate_sent_after_go_for_v2(self, universe, imdsinfo, rate):
+        server = InThreadIMDServer(universe.trajectory)
+        server.set_imdsessioninfo(imdsinfo)
+        server.handshake_sequence("localhost", first_frame=False)
+        client = IMDClient(
+            "localhost",
+            server.port,
+            universe.atoms.n_atoms,
+            transmission_rate=rate,
+        )
+        server.join_accept_thread()
+        server.expect_packet(IMDHeaderType.IMD_TRATE, expected_length=rate)
+        client.stop()
+        server.cleanup()
+
     def test_pause_pause_continue(self, server_client_two_frame_buf):
         server, client = server_client_two_frame_buf
         server.send_frames(0, 2)
@@ -343,6 +374,26 @@ class TestIMDClientV2(IMDClientTest):
         assert second.energies is not None
         assert second.energies["step"] == prev_step
         assert_allclose(pos, second.positions)
+
+    @pytest.mark.parametrize(
+        "packet_type",
+        [
+            IMDHeaderType.IMD_TIME,
+            IMDHeaderType.IMD_BOX,
+            IMDHeaderType.IMD_VELOCITIES,
+            IMDHeaderType.IMD_FORCES,
+        ],
+    )
+    def test_unexpected_packet_type_in_v2(self, server_client, packet_type):
+        """IMDv2 rejects v3-only packet types received before coordinates."""
+        server, client = server_client
+
+        server.conn.sendall(create_header_bytes(packet_type, 1))
+
+        with pytest.raises(EOFError) as exc_info:
+            client.get_imdframe()
+
+        assert f"Unexpected packet type {packet_type.name}" in str(exc_info.value)
 
 
 class TestIMDClientV3ContextManager(IMDClientTest):

--- a/imdclient/tests/test_imdclient.py
+++ b/imdclient/tests/test_imdclient.py
@@ -28,7 +28,6 @@ from .utils import (
     create_default_imdsinfo_v3,
 )
 
-
 logger = logging.getLogger("imdclient.IMDClient")
 file_handler = logging.FileHandler("test.log")
 formatter = logging.Formatter(
@@ -332,18 +331,24 @@ class TestIMDClientV3(IMDClientTest):
         with pytest.raises(RuntimeError, match="An unexpected error occurred"):
             client._producer._get_imdframe()
 
-    def test_trate_not_sent_for_v3(self, universe, imdsinfo):
+    def test_trate_not_sent_for_v3(self, universe, imdsinfo, caplog):
         server = InThreadIMDServer(universe.trajectory)
         server.set_imdsessioninfo(imdsinfo)
         server.handshake_sequence("localhost", first_frame=False)
-        client = IMDClient(
-            "localhost",
-            server.port,
-            universe.atoms.n_atoms,
-            transmission_rate=8,
-        )
+        with caplog.at_level(logging.WARNING):
+            client = IMDClient(
+                "localhost",
+                server.port,
+                universe.atoms.n_atoms,
+                transmission_rate=8,
+            )
         server.join_accept_thread()
         server.expect_no_packet()
+        assert any(
+            "transmission_rate=8 was provided but is ignored for IMDv3"
+            in record.message
+            for record in caplog.records
+        )
         client.stop()
         server.cleanup()
 

--- a/imdclient/tests/test_imdclient.py
+++ b/imdclient/tests/test_imdclient.py
@@ -349,6 +349,25 @@ class TestIMDClientV3(IMDClientTest):
 
 
 class TestIMDClientV2(IMDClientTest):
+    @pytest.mark.parametrize("cont", [True, False])
+    def test_continue_after_disconnect_not_supported_for_v2(
+        self, universe, imdsinfo, cont
+    ):
+        server = InThreadIMDServer(universe.trajectory)
+        server.set_imdsessioninfo(imdsinfo)
+        server.handshake_sequence("localhost", first_frame=False)
+        with pytest.raises(
+            ValueError,
+            match="continue_after_disconnect is only supported for IMDv3",
+        ):
+            IMDClient(
+                "localhost",
+                server.port,
+                universe.atoms.n_atoms,
+                continue_after_disconnect=cont,
+            )
+        server.cleanup()
+
     @pytest.mark.parametrize("rate", [1, 8])
     def test_trate_sent_after_go_for_v2(self, universe, imdsinfo, rate):
         server = InThreadIMDServer(universe.trajectory)

--- a/imdclient/tests/test_lammps.py
+++ b/imdclient/tests/test_lammps.py
@@ -6,8 +6,14 @@ import pytest
 import MDAnalysis as mda
 
 from .minimalreader import MinimalReader
-from .base import IMDv3IntegrationTest
-from .datafiles import LAMMPS_TOPOL, LAMMPS_IN_NST_1, LAMMPS_IN_NST_8
+from .base import IMDv2IntegrationTest, IMDv3IntegrationTest
+from .datafiles import (
+    LAMMPS_TOPOL,
+    LAMMPS_IN_V3_NST_1,
+    LAMMPS_IN_V3_NST_8,
+    LAMMPS_IN_V2_NST_1,
+    LAMMPS_IN_V2_NST_8,
+)
 
 logger = logging.getLogger("imdclient.IMDClient")
 file_handler = logging.FileHandler("lammps_test.log")
@@ -19,11 +25,8 @@ logger.addHandler(file_handler)
 logger.setLevel(logging.DEBUG)
 
 
-class TestIMDv3Lammps(IMDv3IntegrationTest):
-
-    @pytest.fixture(params=[LAMMPS_IN_NST_1, LAMMPS_IN_NST_8])
-    def inp(self, request):
-        return request.param
+class TestIMDLammps:
+    __test__ = False
 
     @pytest.fixture()
     def simulation_command(self, inp):
@@ -47,7 +50,7 @@ class TestIMDv3Lammps(IMDv3IntegrationTest):
 
     @pytest.fixture()
     def first_frame(self, inp):
-        if inp == LAMMPS_IN_NST_1:
+        if inp == LAMMPS_IN_V3_NST_1:
             return 1
         else:
             return 0
@@ -84,3 +87,17 @@ class TestIMDv3Lammps(IMDv3IntegrationTest):
             f"imd://localhost:{port}", n_atoms=n_atoms, process_stream=True
         )
         yield u
+
+
+class TestIMDv3Lammps(TestIMDLammps, IMDv3IntegrationTest):
+
+    @pytest.fixture(params=[LAMMPS_IN_V3_NST_1, LAMMPS_IN_V3_NST_8])
+    def inp(self, request):
+        return request.param
+
+
+class TestIMDv2Lammps(TestIMDLammps, IMDv2IntegrationTest):
+
+    @pytest.fixture(params=[LAMMPS_IN_V2_NST_1, LAMMPS_IN_V2_NST_8])
+    def inp(self, request):
+        return request.param

--- a/imdclient/tests/test_lammps.py
+++ b/imdclient/tests/test_lammps.py
@@ -25,8 +25,7 @@ logger.addHandler(file_handler)
 logger.setLevel(logging.DEBUG)
 
 
-class TestIMDLammps:
-    __test__ = False
+class IMDLammpsTest:
 
     @pytest.fixture()
     def simulation_command(self, inp):
@@ -82,7 +81,7 @@ class TestIMDLammps:
         yield u
 
 
-class TestIMDv3Lammps(TestIMDLammps, IMDv3IntegrationTest):
+class TestIMDv3Lammps(IMDLammpsTest, IMDv3IntegrationTest):
 
     @pytest.fixture(params=[LAMMPS_IN_V3_NST_1, LAMMPS_IN_V3_NST_8])
     def inp(self, request):
@@ -96,7 +95,7 @@ class TestIMDv3Lammps(TestIMDLammps, IMDv3IntegrationTest):
             return 0
 
 
-class TestIMDv2Lammps(TestIMDLammps, IMDv2IntegrationTest):
+class TestIMDv2Lammps(IMDLammpsTest, IMDv2IntegrationTest):
 
     @pytest.fixture(params=[LAMMPS_IN_V2_NST_1, LAMMPS_IN_V2_NST_8])
     def inp(self, request):

--- a/imdclient/tests/test_lammps.py
+++ b/imdclient/tests/test_lammps.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 import MDAnalysis as mda
+from MDAnalysis.transformations.wrap import wrap
 
 from .minimalreader import MinimalReader
 from .base import IMDv2IntegrationTest, IMDv3IntegrationTest
@@ -59,7 +60,7 @@ class IMDLammpsTest:
 
     # This must wait until after imd stream and post-simulation processing has ended
     @pytest.fixture()
-    def true_u(self, topol, traj, imd_u, tmp_path, docker_client):
+    def true_u(self, topol, traj, imd_u, tmp_path, docker_client, first_frame):
         docker_client.wait()
         u = mda.Universe(
             (tmp_path / topol),
@@ -67,6 +68,9 @@ class IMDLammpsTest:
             atom_style="id type x y z",
             convert_units=False,
         )
+        if not imd_u.imdsinfo.wrapped_coords:
+            u.trajectory.add_transformations(wrap(u.atoms, compound="atoms"))
+            imd_u._wrap_trajectory(u, first_frame)
         yield u
 
     @pytest.fixture()

--- a/imdclient/tests/test_lammps.py
+++ b/imdclient/tests/test_lammps.py
@@ -49,13 +49,6 @@ class TestIMDLammps:
     #     return "Waiting for IMD connection on port 8888"
 
     @pytest.fixture()
-    def first_frame(self, inp):
-        if inp == LAMMPS_IN_V3_NST_1:
-            return 1
-        else:
-            return 0
-
-    @pytest.fixture()
     def dt(self, inp):
         pattern = re.compile(r"^\s*timestep\s*(\S+)")
         with open(inp, "r") as file:
@@ -94,6 +87,13 @@ class TestIMDv3Lammps(TestIMDLammps, IMDv3IntegrationTest):
     @pytest.fixture(params=[LAMMPS_IN_V3_NST_1, LAMMPS_IN_V3_NST_8])
     def inp(self, request):
         return request.param
+    
+    @pytest.fixture()
+    def first_frame(self, inp):
+        if inp == LAMMPS_IN_V3_NST_1:
+            return 1
+        else:
+            return 0
 
 
 class TestIMDv2Lammps(TestIMDLammps, IMDv2IntegrationTest):
@@ -101,3 +101,10 @@ class TestIMDv2Lammps(TestIMDLammps, IMDv2IntegrationTest):
     @pytest.fixture(params=[LAMMPS_IN_V2_NST_1, LAMMPS_IN_V2_NST_8])
     def inp(self, request):
         return request.param
+    
+    @pytest.fixture()
+    def first_frame(self, inp):
+        if inp == LAMMPS_IN_V2_NST_1:
+            return 1
+        else:
+            return 0

--- a/imdclient/tests/test_lammps.py
+++ b/imdclient/tests/test_lammps.py
@@ -57,9 +57,10 @@ class IMDLammpsTest:
                     return float(match.group(1))
         raise ValueError(f"No dt found in {inp}")
 
-    # This must wait until after imd stream has ended
+    # This must wait until after imd stream and post-simulation processing has ended
     @pytest.fixture()
-    def true_u(self, topol, traj, imd_u, tmp_path):
+    def true_u(self, topol, traj, imd_u, tmp_path, docker_client):
+        docker_client.wait()
         u = mda.Universe(
             (tmp_path / topol),
             (tmp_path / traj),
@@ -86,7 +87,7 @@ class TestIMDv3Lammps(IMDLammpsTest, IMDv3IntegrationTest):
     @pytest.fixture(params=[LAMMPS_IN_V3_NST_1, LAMMPS_IN_V3_NST_8])
     def inp(self, request):
         return request.param
-    
+
     @pytest.fixture()
     def first_frame(self, inp):
         if inp == LAMMPS_IN_V3_NST_1:
@@ -100,7 +101,7 @@ class TestIMDv2Lammps(IMDLammpsTest, IMDv2IntegrationTest):
     @pytest.fixture(params=[LAMMPS_IN_V2_NST_1, LAMMPS_IN_V2_NST_8])
     def inp(self, request):
         return request.param
-    
+
     @pytest.fixture()
     def first_frame(self, inp):
         if inp == LAMMPS_IN_V2_NST_1:

--- a/imdclient/tests/test_namd.py
+++ b/imdclient/tests/test_namd.py
@@ -33,8 +33,7 @@ logger.addHandler(file_handler)
 logger.setLevel(logging.DEBUG)
 
 
-class TestIMDNAMD:
-    __test__ = False
+class IMDNAMDTest:
 
     @pytest.fixture()
     def container_name(self):
@@ -77,7 +76,7 @@ class TestIMDNAMD:
         return 0
 
 
-class TestIMDv3NAMD(TestIMDNAMD, IMDv3IntegrationTest):
+class TestIMDv3NAMD(IMDNAMDTest, IMDv3IntegrationTest):
 
     @pytest.fixture(params=[NAMD_CONF_V3_NST_1, NAMD_CONF_V3_NST_8])
     def inp(self, request):
@@ -158,7 +157,7 @@ class TestIMDv3NAMD(TestIMDNAMD, IMDv3IntegrationTest):
             )
 
 
-class TestIMDv2NAMD(TestIMDNAMD, IMDv2IntegrationTest):
+class TestIMDv2NAMD(IMDNAMDTest, IMDv2IntegrationTest):
 
     @pytest.fixture(params=[NAMD_CONF_V2_NST_1, NAMD_CONF_V2_NST_8])
     def inp(self, request):

--- a/imdclient/tests/test_namd.py
+++ b/imdclient/tests/test_namd.py
@@ -8,11 +8,17 @@ from numpy.testing import (
 )
 import MDAnalysis as mda
 
-from .base import IMDv3IntegrationTest, assert_allclose_with_logging
+from .base import (
+    IMDv2IntegrationTest,
+    IMDv3IntegrationTest,
+    assert_allclose_with_logging,
+)
 from .datafiles import (
     NAMD_TOPOL,
-    NAMD_CONF_NST_1,
-    NAMD_CONF_NST_8,
+    NAMD_CONF_V3_NST_1,
+    NAMD_CONF_V3_NST_8,
+    NAMD_CONF_V2_NST_1,
+    NAMD_CONF_V2_NST_8,
     NAMD_PARAMS,
     NAMD_PSF,
 )
@@ -27,15 +33,12 @@ logger.addHandler(file_handler)
 logger.setLevel(logging.DEBUG)
 
 
-class TestIMDv3NAMD(IMDv3IntegrationTest):
+class TestIMDNAMD:
+    __test__ = False
 
     @pytest.fixture()
     def container_name(self):
         return "ghcr.io/becksteinlab/streaming-namd-docker:main-common-cpu"
-
-    @pytest.fixture(params=[NAMD_CONF_NST_1, NAMD_CONF_NST_8])
-    def inp(self, request):
-        return request.param
 
     @pytest.fixture()
     def simulation_command(self, inp):
@@ -70,6 +73,17 @@ class TestIMDv3NAMD(IMDv3IntegrationTest):
         yield u
 
     @pytest.fixture()
+    def first_frame(self):
+        return 0
+
+
+class TestIMDv3NAMD(TestIMDNAMD, IMDv3IntegrationTest):
+
+    @pytest.fixture(params=[NAMD_CONF_V3_NST_1, NAMD_CONF_V3_NST_8])
+    def inp(self, request):
+        return request.param
+
+    @pytest.fixture()
     def true_u_vel(self, topol, imd_u, tmp_path):
         u = mda.Universe(
             (tmp_path / topol),
@@ -88,10 +102,6 @@ class TestIMDv3NAMD(IMDv3IntegrationTest):
     # @pytest.fixture()
     # def match_string(self):
     #     return "INTERACTIVE MD AWAITING CONNECTION"
-
-    @pytest.fixture()
-    def first_frame(self):
-        return 0
 
     # Compare coords, box, time, dt, step
     def test_compare_imd_to_true_traj(self, imd_u, true_u, first_frame, dt):
@@ -146,3 +156,10 @@ class TestIMDv3NAMD(IMDv3IntegrationTest):
                 imd_u.trajectory[i - first_frame].forces,
                 atol=1e-03,
             )
+
+
+class TestIMDv2NAMD(TestIMDNAMD, IMDv2IntegrationTest):
+
+    @pytest.fixture(params=[NAMD_CONF_V2_NST_1, NAMD_CONF_V2_NST_8])
+    def inp(self, request):
+        return request.param

--- a/imdclient/tests/test_namd.py
+++ b/imdclient/tests/test_namd.py
@@ -7,6 +7,7 @@ from numpy.testing import (
     assert_allclose,
 )
 import MDAnalysis as mda
+from MDAnalysis.transformations.wrap import wrap
 
 from .base import (
     IMDv2IntegrationTest,
@@ -64,11 +65,14 @@ class IMDNAMDTest:
         raise ValueError(f"No dt found in {inp}")
 
     @pytest.fixture()
-    def true_u(self, topol, imd_u, tmp_path):
+    def true_u(self, topol, imd_u, tmp_path, first_frame):
         u = mda.Universe(
             (tmp_path / topol),
             (tmp_path / "alanin.dcd"),
         )
+        if not imd_u.imdsinfo.wrapped_coords:
+            u.trajectory.add_transformations(wrap(u.atoms, compound="atoms"))
+            imd_u._wrap_trajectory(u, first_frame)
         yield u
 
     @pytest.fixture()

--- a/imdclient/tests/utils.py
+++ b/imdclient/tests/utils.py
@@ -10,12 +10,13 @@ def create_default_imdsinfo_v2():
     return IMDSessionInfo(
         version=2,
         endianness="<",
-        wrapped_coords=True,
+        time=False,
         energies=True,
         box=False,
         positions=True,
         velocities=False,
         forces=False,
+        wrapped_coords=True,
     )
 
 

--- a/imdclient/tests/utils.py
+++ b/imdclient/tests/utils.py
@@ -2,7 +2,6 @@ from imdclient.IMDProtocol import *
 import socket
 import logging
 
-
 logger = logging.getLogger("imdclient.IMDClient")
 
 


### PR DESCRIPTION

<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

This PR provides generic IMDv2 support for handling various v2 streaming scenarios in `imdclient` 

Fixes #140 , #143

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - IMDv2 schema as described in #140
 - intergation tests for IMDv2 simulationengine implementationss
 - unit test for IMDClientv2
 - box wrapping for TRR and IMD based checking when using v2 or `IMD-unwrap=True` in session info
 - v2 `trate` sending via `IMDClient` object
 - Added v2 tests addressing #82 
 
Note: IMDv2 in GROMACS seems to expects transmission rate from the user via the client, as discussed in #143  
It ignores `IMD-nst` in the `*.mdp` file. Thus the `IMDClient` object was modified to send `IMD_TRATE` right after `IMD_GO` as set in the object initiation when using v2.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
